### PR TITLE
docs(update-pagination): Pagination addition about the first position

### DIFF
--- a/chapters/integration/generic/pagination.adoc
+++ b/chapters/integration/generic/pagination.adoc
@@ -138,6 +138,11 @@ this may comprise the support for {prev}, {first}, {last}, and {self} as
 {link-relations}[link relations] (see also <<link-relation-fields>> for
 details).
 
+The first position should be 1, and every next position should be increased by 1.
+https://google.aip.dev/158#guidance
+
+If the next position doesn't have results, it shoudn't return a link.
+
 The page content is transported via {items}, while the {query} object may
 contain the query filters applied to the collection resource as follows:
 


### PR DESCRIPTION
Added more information about e.g. the first page of the pagination.
Based on the API Improvement Proposal Guidelines of Google: https://google.aip.dev/158#guidance

Check also a second proposal: https://github.com/pondevelopment/restful-api-guidelines/pull/37