### PR TITLE
docs(update-pagination): Pagination addition about the first position, should be zero

### DIFF
--- a/chapters/integration/generic/pagination.adoc
+++ b/chapters/integration/generic/pagination.adoc
@@ -138,6 +138,13 @@ this may comprise the support for {prev}, {first}, {last}, and {self} as
 {link-relations}[link relations] (see also <<link-relation-fields>> for
 details).
 
+The first position at the api pagination should be 0, and every next position should be increased by 1.
+Starting with zero makes the math simple.
+API is designed to consumed by another system, and all code starts lists with zero.
+https://en.wikipedia.org/wiki/Zero-based_numbering
+
+If the next position doesn't have results, it shoudn't return a link.
+
 The page content is transported via {items}, while the {query} object may
 contain the query filters applied to the collection resource as follows:
 


### PR DESCRIPTION
Added more information about e.g. the first page of the pagination.

Based on:
https://en.wikipedia.org/wiki/Zero-based_numbering
https://www.cs.utexas.edu/users/EWD/transcriptions/EWD08xx/EWD831.html

Alternative to: https://github.com/pondevelopment/restful-api-guidelines/pull/36

You see that it's easier to have a 0-indexed paging for developers.

1-indexed pagination makes more sense to human users, because we start with 1 when counting everything.

But an API is created to be consumed by systems, and developers build code to use it, it's not data for humans to read in the frondend.